### PR TITLE
tests with and without API client

### DIFF
--- a/tests/auth-and-order-flow.spec.ts
+++ b/tests/auth-and-order-flow.spec.ts
@@ -2,10 +2,9 @@ import { expect, test } from '@playwright/test';
 import { StatusCodes } from 'http-status-codes';
 import { LoginDto } from './dto/login-dto';
 import { OrderDto } from './dto/order-dto';
-
-const serviceURL = 'https://backend.tallinn-learning.ee/';
-const loginPath = 'login/student';
-const orderPath = 'orders';
+import { loginAndCreateOrder } from './helpers/order-utils';
+import { getAuthHeaders } from './helpers/order-utils';
+import { serviceURL, paths } from './helpers/config';
 
 const jwtPattern = /^eyJhb[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/;
 
@@ -13,7 +12,7 @@ test.describe('Tallinn delivery API tests', () => {
   test('login with correct data and verify auth token', async ({ request }) => {
     const requestBody = LoginDto.createLoginWithCorrectData();
     console.log('requestBody:', requestBody);
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: requestBody
     });
     const responseBody = await response.text();
@@ -31,7 +30,7 @@ test.describe('Tallinn delivery API tests', () => {
   test('login with incorrect data and verify response code 401', async ({ request }) => {
     const requestBody = LoginDto.createLoginWithIncorrectData();
     console.log('requestBody:', requestBody);
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: requestBody
     });
     const responseBody = await response.text();
@@ -44,11 +43,11 @@ test.describe('Tallinn delivery API tests', () => {
 
   test('login and create order', async ({ request }) => {
     const requestBody = LoginDto.createLoginWithCorrectData();
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: requestBody
     });
     const jwt = await response.text();
-    const orderResponse = await request.post(`${serviceURL}${orderPath}`, {
+    const orderResponse = await request.post(`${serviceURL}${paths.order}`, {
       data: OrderDto.createOrderWithoutId(),
       headers: {
         Authorization: `Bearer ${jwt}`
@@ -65,7 +64,7 @@ test.describe('Tallinn delivery API tests', () => {
 
   test('request with invalid HTTP method returns 405', async ({ request }) => {
     const requestBody = LoginDto.createLoginWithCorrectData();
-    const response = await request.get(`${serviceURL}${loginPath}`, {
+    const response = await request.get(`${serviceURL}${paths.login}`, {
       data: requestBody
     });
     expect(response.status()).toBe(StatusCodes.METHOD_NOT_ALLOWED);
@@ -74,14 +73,14 @@ test.describe('Tallinn delivery API tests', () => {
   test('request with array instead of object returns 400', async ({ request }) => {
     const requestBody = LoginDto.createLoginWithCorrectData();
     const invalidRequestBody = [requestBody];
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: invalidRequestBody
     });
     expect(response.status()).toBe(StatusCodes.BAD_REQUEST);
   });
 
   test('request with string instead of object returns 400', async ({ request }) => {
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: 'username=test&password=test',
       headers: {
         'Content-Type': 'application/json'
@@ -91,7 +90,7 @@ test.describe('Tallinn delivery API tests', () => {
   });
 
   test('request with empty body returns 4xx', async ({ request }) => {
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: {},
       headers: {
         'Content-Type': 'application/json'
@@ -101,7 +100,7 @@ test.describe('Tallinn delivery API tests', () => {
   });
 
   test('request with null body returns 400', async ({ request }) => {
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: null
     });
     expect(response.status()).toBe(StatusCodes.BAD_REQUEST);
@@ -112,7 +111,7 @@ test.describe('Tallinn delivery API tests', () => {
     const invalidRequestBody = {
       password: requestBody.password
     };
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: invalidRequestBody
     });
     expect(response.status()).not.toBe(StatusCodes.OK);
@@ -123,7 +122,7 @@ test.describe('Tallinn delivery API tests', () => {
     const invalidRequestBody = {
       username: requestBody.username
     };
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: invalidRequestBody
     });
     expect(response.status()).not.toBe(StatusCodes.OK);
@@ -131,12 +130,58 @@ test.describe('Tallinn delivery API tests', () => {
 
   test('request with wrong content-type header returns 415', async ({ request }) => {
     const requestBody = LoginDto.createLoginWithCorrectData();
-    const response = await request.post(`${serviceURL}${loginPath}`, {
+    const response = await request.post(`${serviceURL}${paths.login}`, {
       data: requestBody,
       headers: {
         'Content-Type': 'text/plain'
       }
     });
     expect(response.status()).toBe(StatusCodes.UNSUPPORTED_MEDIA_TYPE);
+  });
+});
+
+test.describe('tests without using API client', () => {
+  let jwt: string;
+  let orderId: number;
+
+  test.beforeEach(async ({ request }) => {
+    const result = await loginAndCreateOrder(request);
+    jwt = result.jwt;
+    orderId = result.orderId;
+  });
+
+  test('successful authorization and finding order by id', async ({ request }) => {
+    const findOrderResponse = await request.get(`${serviceURL}${paths.order}/${orderId}`, {
+      headers: getAuthHeaders(jwt)
+    });
+    const foundOrder = await findOrderResponse.json();
+    console.log('Order found:', foundOrder);
+    expect.soft(findOrderResponse.status(), 'Order should be found by id').toBe(StatusCodes.OK);
+    expect.soft(foundOrder.id).toBe(orderId);
+  });
+
+  test('successful authorization and deleting order by id', async ({ request }) => {
+    const deleteResponse = await request.delete(`${serviceURL}${paths.delete}/${orderId}`, {
+      headers: getAuthHeaders(jwt)
+    });
+    const deletedOrderBody = await deleteResponse.json();
+    console.log('delete order status code: ', deleteResponse.status());
+    console.log('deleted order body ', deletedOrderBody);
+    expect.soft(deleteResponse.status()).toBe(StatusCodes.OK);
+
+    const getResponse = await request.get(`${serviceURL}${paths.get}/${orderId}`, {
+      headers: getAuthHeaders(jwt)
+    });
+    expect.soft([StatusCodes.OK, StatusCodes.NOT_FOUND].includes(getResponse.status())).toBeTruthy();
+    const getResponseText = await getResponse.text();
+    expect.soft(getResponseText).toBe('');
+    console.log('get deleted order status code: ', getResponse.status());
+    console.log('get deleted order response body: ', getResponseText);
+
+    if (getResponseText === '') {
+      console.log('Order was deleted successfully — no data returned.');
+    } else {
+      console.log('Unexpected response body for deleted order:', getResponseText);
+    }
   });
 });

--- a/tests/auth-tests-with-api-client.spec.ts
+++ b/tests/auth-tests-with-api-client.spec.ts
@@ -2,18 +2,48 @@ import { expect, test } from '@playwright/test';
 import { ApiClient } from './api/api-client';
 import { StatusCodes } from 'http-status-codes';
 
-test('login and create order with api client', async ({ request }) => {
-  const apiClient = await ApiClient.getInstance(request);
-  const orderId = await apiClient.createOrderAndReturnOrderId();
-  console.log('orderId:', orderId);
-});
+test.describe('auth tests with API Client', () => {
+  let apiClient: ApiClient;
+  let orderId: number;
 
-test('login and delete an existing order with api client', async ({ request }) => {
-  const apiClient = await ApiClient.getInstance(request);
-  const orderId = await apiClient.createOrderAndReturnOrderId();
-  console.log('orderId:', orderId);
-  const response = await apiClient.deleteOrder(orderId);
-  const responseBody = await response.ok();
-  expect(response.status()).toBe(StatusCodes.OK);
-  expect(responseBody).toBeTruthy();
+  test.beforeEach(async ({ request }) => {
+    apiClient = await ApiClient.getInstance(request);
+    orderId = await apiClient.createOrderAndReturnOrderId();
+    expect.soft(orderId).toBeDefined();
+  });
+
+  test('login and create order', async () => {
+    console.log('orderId:', orderId);
+  });
+
+  test('login and delete an existing order', async () => {
+    console.log('orderId:', orderId);
+    const response = await apiClient.deleteOrder(orderId);
+    const responseBody = await response.ok();
+    expect(response.status()).toBe(StatusCodes.OK);
+    expect(responseBody).toBeTruthy();
+  });
+
+  test('should create an order and retrieve it by id', async () => {
+    const foundOrder = await apiClient.findOrder(orderId);
+    expect.soft(foundOrder).toBeDefined();
+    expect.soft(foundOrder.id).toBe(orderId);
+  });
+
+  test('should create an order, delete it and verify that it is deleted', async () => {
+    const deleteResponse = await apiClient.deleteOrder(orderId);
+    expect.soft(deleteResponse.status()).toBe(StatusCodes.OK);
+
+    const getDeletedOrderResponse = await apiClient.getOrderResponseRaw(orderId);
+    expect.soft([StatusCodes.OK, StatusCodes.NOT_FOUND].includes(getDeletedOrderResponse.status())).toBeTruthy();
+
+    const bodyText = await getDeletedOrderResponse.text();
+    expect.soft(bodyText).toBe('');
+
+    if (bodyText === '') {
+      console.log('Order was deleted successfully — no data returned.');
+    } else {
+      console.log('Unexpected response body for deleted order:', bodyText);
+    }
+  });
 });

--- a/tests/helpers/config.ts
+++ b/tests/helpers/config.ts
@@ -1,0 +1,8 @@
+export const serviceURL = 'https://backend.tallinn-learning.ee';
+
+export const paths = {
+  login: '/login/student',
+  order: '/orders',
+  delete: '/orders',
+  get: '/orders'
+};

--- a/tests/helpers/order-utils.ts
+++ b/tests/helpers/order-utils.ts
@@ -1,0 +1,39 @@
+import { APIRequestContext, expect } from '@playwright/test';
+import { LoginDto } from '../dto/login-dto';
+import { OrderDto } from '../dto/order-dto';
+import { StatusCodes } from 'http-status-codes';
+import { serviceURL, paths } from './config';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function getAuthHeaders(jwt: string) {
+  return {
+    Authorization: `Bearer ${jwt}`
+  };
+}
+
+export async function loginAndCreateOrder(request: APIRequestContext): Promise<{ jwt: string; orderId: number }> {
+  const loginData = LoginDto.createLoginWithCorrectData();
+  const orderData = OrderDto.createOrderWithRandomData();
+
+  const loginResponse = await request.post(`${serviceURL}${paths.login}`, {
+    data: loginData
+  });
+
+  expect.soft(loginResponse.status()).toBe(StatusCodes.OK);
+  const jwt = await loginResponse.text();
+
+  const orderResponse = await request.post(`${serviceURL}${paths.order}`, {
+    data: orderData,
+    headers: {
+      Authorization: `Bearer ${jwt}`
+    }
+  });
+
+  expect.soft(orderResponse.status()).toBe(StatusCodes.OK);
+  const responseBody = await orderResponse.json();
+
+  return {
+    jwt,
+    orderId: responseBody.id
+  };
+}


### PR DESCRIPTION
api-client.ts:
– added findOrder(), getOrderResponseRaw()
– deleted constants serviceUrl, loginPath, orderPath, deletePath – added {serviceURL, paths} from '../helpers/config' – updated all the paths in the file
– deleted part of console.log lines

auth-and-order-flow.spec.ts:
– deleted constants serviceUrl, loginPath, orderPath – added {loginAndCreatedOrder} from './helpers/order-utils' – added {getAuthHeaders} from './helpers/order-utils' – added {serviceURL, paths} from './helpers/config' – updated all already existing paths in the file
– added new test.describe – 'tests without using API client' and added two new tests in it

auth-tests-with-api-client.spec.ts:
– added test.describe – 'auth tests with API Client' and hook beforeEach (w/variables apiClient and orderId) – expect.soft(orderId).toBeDefined() moved to beforeEach hook – added two tests: 'should create an order and retrieve it by id' and 'should create an order, delete it and verify that it is deleted'

– added config.ts

– added order-utils.ts